### PR TITLE
Added a missing comma after the 'null' argument in the lighthouse.uploadEncrypted function call

### DIFF
--- a/javascript/code-examples/browser-with-encryption.md
+++ b/javascript/code-examples/browser-with-encryption.md
@@ -76,7 +76,7 @@ function App() {
       "YOUR_API_KEY",
       sig.publicKey,
       sig.signedMessage,
-      null
+      null,
       progressCallback
     );
     console.log(response);


### PR DESCRIPTION
To ensure to have correct syntax and parameter order. ',' expected.To fix this added a comma right after null.