### PR TITLE
fix: updated get balance API to use token instead of public key as params.

### DIFF
--- a/how-to/get-balance.md
+++ b/how-to/get-balance.md
@@ -18,30 +18,36 @@ Users can check their account balance with the given command. It returns the dat
 
 {% tabs %}
 {% tab title="JS SDK" %}
+
 ```javascript
-const getBalance = async() => {
+const getBalance = async () => {
   /*
     @param {string} apiKey - your api key.
   */
-  const apiKey = 'YOUR_API_KEY';
+  const apiKey = "YOUR_API_KEY";
   const balance = await lighthouse.getBalance(apiKey);
-  
+
   /* Sample Response (Unit is Bytes)
       {data: { dataLimit: 687194767360, dataUsed: 7012827847 }}
   */
-}
+};
 ```
+
 {% endtab %}
 
 {% tab title="API" %}
+
 ```bash
-curl https://api.lighthouse.storage/api/user/user_data_usage?publicKey=<publicKey>
+curl -H 'Authorization: Bearer API_KEY' https://api.lighthouse.storage/api/user/user_data_usage
 ```
+
 {% endtab %}
 
 {% tab title="CLI" %}
+
 ```bash
 lighthouse-web3 balance
 ```
+
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
# What have I changed
Fixed the get balance API to use the token instead of the public key as params

# Why have I changed 
Since get balance API uses token instead of public key.